### PR TITLE
Bug/app 519 innacurate date validation

### DIFF
--- a/lib/src/logic/type_converter.dart
+++ b/lib/src/logic/type_converter.dart
@@ -16,7 +16,9 @@ class StringDoubleTypeConverter extends TypeConverter<String, double> {
   double? canConvert(String inputType) {
     double convertedDouble;
     try {
+      if(inputType.isNotEmpty){
       convertedDouble = NumberFormat().parse(inputType) as double;
+      }
     } on FormatException catch (_) {
       return null;
     } on TypeError catch (_) {

--- a/lib/src/logic/type_converter.dart
+++ b/lib/src/logic/type_converter.dart
@@ -14,7 +14,7 @@ abstract class TypeConverter<InputType, OutputType> {
 class StringDoubleTypeConverter extends TypeConverter<String, double> {
   @override
   double? canConvert(String inputType) {
-    double convertedDouble;
+    double? convertedDouble;
     try {
       if(inputType.isNotEmpty){
       convertedDouble = NumberFormat().parse(inputType) as double;

--- a/lib/src/logic/type_converter.dart
+++ b/lib/src/logic/type_converter.dart
@@ -14,11 +14,9 @@ abstract class TypeConverter<InputType, OutputType> {
 class StringDoubleTypeConverter extends TypeConverter<String, double> {
   @override
   double? canConvert(String inputType) {
-    double? convertedDouble;
+    double convertedDouble;
     try {
-      if(inputType.isNotEmpty){
       convertedDouble = NumberFormat().parse(inputType) as double;
-      }
     } on FormatException catch (_) {
       return null;
     } on TypeError catch (_) {

--- a/lib/src/logic/validators.dart
+++ b/lib/src/logic/validators.dart
@@ -264,7 +264,7 @@ class ShouldInBetweenDatesValidator<KeyType>
 
   @override
   bool isValid(DateTime date) {
-    return (date.compareTo(min) > 0 && date.compareTo(max) < 0);
+    return (date.isBetween(min, max));
   }
 
   @override
@@ -416,4 +416,40 @@ class ShouldBeBetweenOrEqualValidator<KeyType>
 
   @override
   List<Object?> get props => [...super.props, min, max];
+}
+
+
+  extension DateTimeExtension on DateTime? {
+  
+  bool? isAfterOrEqualTo(DateTime dateTime) {
+    final date = this;
+    if (date != null) {
+      final isAtSameMomentAs = dateTime.isAtSameMomentAs(date);
+      return isAtSameMomentAs | date.isAfter(dateTime);
+    }
+    return null;
+  }
+
+  bool? isBeforeOrEqualTo(DateTime dateTime) {
+    final date = this;
+    if (date != null) {
+      final isAtSameMomentAs = dateTime.isAtSameMomentAs(date);
+      return isAtSameMomentAs | date.isBefore(dateTime);
+    }
+    return null;
+  }
+
+  bool isBetween(
+    DateTime fromDateTime,
+    DateTime toDateTime,
+  ) {
+    final date = this;
+    if (date != null) {
+      final isAfter = date.isAfterOrEqualTo(fromDateTime) ?? false;
+      final isBefore = date.isBeforeOrEqualTo(toDateTime) ?? false;
+      return isAfter && isBefore;
+    }
+    return false;
+  }
+
 }

--- a/lib/src/logic/validators.dart
+++ b/lib/src/logic/validators.dart
@@ -249,11 +249,11 @@ class ShouldInBetweenDatesValidator<KeyType>
     extends FieldValidator<DateTime, KeyType, ShouldInBetweenDatesValidator<KeyType>> {
   final DateTime max;
   final DateTime min;
-  final bool useExtension;
+  final bool isInclusive;
 
   ShouldInBetweenDatesValidator(
       {required this.min,
-       this.useExtension = false, 
+       this.isInclusive = false, 
       required this.max,
       String Function(ShouldInBetweenDatesValidator<KeyType> validator, Field field)? buildErrorMessage,
       KeyType? key})
@@ -266,7 +266,7 @@ class ShouldInBetweenDatesValidator<KeyType>
 
   @override
   bool isValid(DateTime date) {
-    if(useExtension){
+    if(isInclusive){
       return (date.isBetween(min, max));
     }else {
       return (date.compareTo(min) >= 0 && date.compareTo(max) <= 0);

--- a/lib/src/logic/validators.dart
+++ b/lib/src/logic/validators.dart
@@ -267,9 +267,9 @@ class ShouldInBetweenDatesValidator<KeyType>
   @override
   bool isValid(DateTime date) {
     if(isInclusive){
-      return (date.isBetween(min, max));
-    }else {
       return (date.compareTo(min) >= 0 && date.compareTo(max) <= 0);
+    }else {
+      return (date.compareTo(min) > 0 && date.compareTo(max) < 0);
     }
   }
 
@@ -422,32 +422,4 @@ class ShouldBeBetweenOrEqualValidator<KeyType>
 
   @override
   List<Object?> get props => [...super.props, min, max];
-}
-
-
-  extension DateTimeExtension on DateTime {
-  
-  bool isAfterOrEqualTo(DateTime dateTime) {
-      final isAtSameMomentAs = dateTime.isAtSameMomentAs(this);
-      return isAtSameMomentAs || isAfter(dateTime);
-  }
-
-  bool isBeforeOrEqualTo(DateTime dateTime) {
-    final date = this;
-   
-      final isAtSameMomentAs = dateTime.isAtSameMomentAs(date);
-      return isAtSameMomentAs || date.isBefore(dateTime);
-
-  }
-
-  bool isBetween(
-    DateTime fromDateTime,
-    DateTime toDateTime,
-  ) {
-      final isAfter = isAfterOrEqualTo(fromDateTime) ;
-      final isBefore = isBeforeOrEqualTo(toDateTime) ;
-      return isAfter && isBefore;
-    }
-  
-  
 }

--- a/lib/src/logic/validators.dart
+++ b/lib/src/logic/validators.dart
@@ -249,9 +249,11 @@ class ShouldInBetweenDatesValidator<KeyType>
     extends FieldValidator<DateTime, KeyType, ShouldInBetweenDatesValidator<KeyType>> {
   final DateTime max;
   final DateTime min;
+  final bool useExtension;
 
   ShouldInBetweenDatesValidator(
       {required this.min,
+       this.useExtension = false, 
       required this.max,
       String Function(ShouldInBetweenDatesValidator<KeyType> validator, Field field)? buildErrorMessage,
       KeyType? key})
@@ -264,7 +266,11 @@ class ShouldInBetweenDatesValidator<KeyType>
 
   @override
   bool isValid(DateTime date) {
-    return (date.isBetween(min, max));
+    if(useExtension){
+      return (date.isBetween(min, max));
+    }else {
+      return (date.compareTo(min) >= 0 && date.compareTo(max) <= 0);
+    }
   }
 
   @override
@@ -419,37 +425,29 @@ class ShouldBeBetweenOrEqualValidator<KeyType>
 }
 
 
-  extension DateTimeExtension on DateTime? {
+  extension DateTimeExtension on DateTime {
   
-  bool? isAfterOrEqualTo(DateTime dateTime) {
-    final date = this;
-    if (date != null) {
-      final isAtSameMomentAs = dateTime.isAtSameMomentAs(date);
-      return isAtSameMomentAs | date.isAfter(dateTime);
-    }
-    return null;
+  bool isAfterOrEqualTo(DateTime dateTime) {
+      final isAtSameMomentAs = dateTime.isAtSameMomentAs(this);
+      return isAtSameMomentAs || isAfter(dateTime);
   }
 
-  bool? isBeforeOrEqualTo(DateTime dateTime) {
+  bool isBeforeOrEqualTo(DateTime dateTime) {
     final date = this;
-    if (date != null) {
+   
       final isAtSameMomentAs = dateTime.isAtSameMomentAs(date);
-      return isAtSameMomentAs | date.isBefore(dateTime);
-    }
-    return null;
+      return isAtSameMomentAs || date.isBefore(dateTime);
+
   }
 
   bool isBetween(
     DateTime fromDateTime,
     DateTime toDateTime,
   ) {
-    final date = this;
-    if (date != null) {
-      final isAfter = date.isAfterOrEqualTo(fromDateTime) ?? false;
-      final isBefore = date.isBeforeOrEqualTo(toDateTime) ?? false;
+      final isAfter = isAfterOrEqualTo(fromDateTime) ;
+      final isBefore = isBeforeOrEqualTo(toDateTime) ;
       return isAfter && isBefore;
     }
-    return false;
-  }
-
+  
+  
 }

--- a/test/invalid_test.dart
+++ b/test/invalid_test.dart
@@ -336,6 +336,61 @@ void main() {
             false);
       });
     });
+group('ShouldInBetweenDatesValidator', () {
+    test('Valid date within range (inclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: true,
+      );
+      expect(validator.isValid(DateTime(2022, 6, 15)), true);
+    });
+
+    test('Valid date within range (exclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: false,
+      );
+      expect(validator.isValid(DateTime(2022, 6, 15)), true);
+    });
+
+    test('Invalid date before range (inclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: true,
+      );
+      expect(validator.isValid(DateTime(2021, 12, 31)), false);
+    });
+
+    test('Invalid date after range (inclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: true,
+      );
+      expect(validator.isValid(DateTime(2023, 1, 1)), false);
+    });
+
+    test('valid date equal to min in range (Inclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: true,
+      );
+      expect(validator.isValid(DateTime(2022, 1, 1)), true);
+    });
+
+    test('valid date equal to max in range (Inclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: true,
+      );
+      expect(validator.isValid(DateTime(2022, 12, 31)), true);
+    });
+  });
   });
 }
 

--- a/test/invalid_test.dart
+++ b/test/invalid_test.dart
@@ -390,6 +390,24 @@ group('ShouldInBetweenDatesValidator', () {
       );
       expect(validator.isValid(DateTime(2022, 12, 31)), true);
     });
+
+    test('valid date equal to min in range (Exclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: false,
+      );
+      expect(validator.isValid(DateTime(2022, 1, 1)), false);
+    });
+
+    test('valid date equal to max in range (Exclusive)', () {
+      final validator = ShouldInBetweenDatesValidator<DateTime>(
+        min: DateTime(2022, 1, 1),
+        max: DateTime(2022, 12, 31),
+        isInclusive: false,
+      );
+      expect(validator.isValid(DateTime(2022, 12, 31)), false);
+    });
   });
   });
 }


### PR DESCRIPTION
Added an extra parameter to `ShouldInBetweenDatesValidator` to configure whether validation applies inclusively (including boundary dates) or exclusively. 